### PR TITLE
fix: Werkzeug bearbeiten setzt Status nicht mehr zurück

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -697,6 +697,17 @@
                         <input type="text" id="werkzeugInventarnummer">
                     </div>
                     <div class="form-group">
+                        <label for="werkzeugStatus">Status</label>
+                        <select id="werkzeugStatus">
+                            <option value="verfuegbar">Verfügbar</option>
+                            <option value="reserviert">Reserviert</option>
+                            <option value="ausgeliehen">Ausgeliehen</option>
+                            <option value="defekt">Defekt</option>
+                            <option value="reinigung">Reinigung</option>
+                            <option value="reparatur">Reparatur</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
                         <label for="werkzeugZustand">Zustand</label>
                         <input type="text" id="werkzeugZustand">
                     </div>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -448,6 +448,7 @@ async function editWerkzeug(id) {
         document.getElementById('werkzeugIcon').value = werkzeug.icon || '';
         document.getElementById('werkzeugBeschreibung').value = werkzeug.beschreibung || '';
         document.getElementById('werkzeugInventarnummer').value = werkzeug.inventarnummer;
+        document.getElementById('werkzeugStatus').value = werkzeug.status || 'verfuegbar';
         document.getElementById('werkzeugZustand').value = werkzeug.zustand || '';
         document.getElementById('werkzeugKategorie').value = werkzeug.kategorie || '';
         document.getElementById('werkzeugLagerplatz').value = werkzeug.lagerplatz || '';
@@ -484,6 +485,7 @@ async function saveWerkzeug(event) {
         icon: document.getElementById('werkzeugIcon').value,
         beschreibung: document.getElementById('werkzeugBeschreibung').value,
         inventarnummer: document.getElementById('werkzeugInventarnummer').value,
+        status: document.getElementById('werkzeugStatus').value,
         zustand: document.getElementById('werkzeugZustand').value,
         kategorie: document.getElementById('werkzeugKategorie').value,
         lagerplatz: document.getElementById('werkzeugLagerplatz').value
@@ -498,7 +500,6 @@ async function saveWerkzeug(event) {
     try {
         if (id) {
             // Bearbeiten
-            data.status = 'verfuegbar'; // Behalte aktuellen Status bei
             await apiCall(`/werkzeuge/${id}`, {
                 method: 'PUT',
                 body: JSON.stringify(data)


### PR DESCRIPTION
## Summary

Der Bearbeitungsdialog übernimmt jetzt den aktuellen Werkzeug-Status korrekt und sendet ihn beim Speichern mit, statt ihn stillschweigend auf `verfuegbar` zurückzusetzen.

## Changes

- Status-Dropdown im Werkzeug-Edit-Modal ergänzt
- aktuellen `werkzeug.status` beim Laden des Formulars vorbelegt
- `saveWerkzeug()` sendet den gewählten Status mit
- hart kodiertes Zurücksetzen auf `verfuegbar` entfernt

## Testing

- `node --check frontend/main.js`
- `node --check frontend/server.js`
- `node --check backend/server.js`
- `node --check backend/init-db.js`

Fixes Markusianus/werkzeugausleihe-app-azure#4