### PR TITLE
fix: vervollständige Dashboard-Statistiken im HTML

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -574,7 +574,7 @@
                     <div class="dashboard">
                         <div class="dashboard-card">
                             <h3 id="statGesamt">-</h3>
-                            <p>Gesamt</p>
+                            <p>Gesamt Werkzeuge</p>
                         </div>
                         <div class="dashboard-card">
                             <h3 id="statVerfuegbar">-</h3>
@@ -582,18 +582,37 @@
                         </div>
                         <div class="dashboard-card">
                             <h3 id="statReserviert">-</h3>
-                            <p>Reserviert</p>
+                            <p>Werkzeuge reserviert</p>
                         </div>
                         <div class="dashboard-card">
                             <h3 id="statAusgeliehen">-</h3>
-                            <p>Ausgeliehen</p>
+                            <p>Werkzeuge ausgeliehen</p>
                         </div>
                         <div class="dashboard-card">
                             <h3 id="statDefekt">-</h3>
                             <p>Defekt</p>
                         </div>
+                        <div class="dashboard-card">
+                            <h3 id="statAusleihenReserviert">-</h3>
+                            <p>Ausleihen reserviert</p>
+                        </div>
+                        <div class="dashboard-card">
+                            <h3 id="statAusleihenAusgeliehen">-</h3>
+                            <p>Ausleihen aktiv</p>
+                        </div>
+                        <div class="dashboard-card alert">
+                            <h3 id="statAusleihenUeberfaellig">-</h3>
+                            <p>Überfällige Ausleihen</p>
+                        </div>
+                        <div class="dashboard-card alert">
+                            <h3 id="statSchaeden">-</h3>
+                            <p>Offene Schäden</p>
+                        </div>
                     </div>
-                    <div id="topWerkzeugeList"></div>
+                    <div>
+                        <h3>Top Werkzeuge</h3>
+                        <ul id="topWerkzeugeList"></ul>
+                    </div>
                 </section>
 
                 <section class="section">


### PR DESCRIPTION
## Summary

Das Admin-Dashboard enthält jetzt die fehlenden DOM-Elemente für Ausleihen-Statistiken, offene Schäden und die Top-5-Werkzeugliste, sodass die bereits gelieferten `/api/stats`-Daten vollständig dargestellt werden.

## Changes

- fehlende Dashboard-Karten für reservierte/aktive/überfällige Ausleihen ergänzt
- Karte für offene Schäden ergänzt
- Top-Werkzeuge-Liste als `<ul>` mit Überschrift ergänzt
- vorhandene IDs an die bereits verwendete `main.js`-Logik angeschlossen

## Testing

- `node --check frontend/main.js`
- `node --check frontend/server.js`

Fixes Markusianus/werkzeugausleihe-app-azure#3